### PR TITLE
[GH-6357] Add missing Rubyzen APIs when parsing tests

### DIFF
--- a/.github/workflows/rubyzen-analysis.yml
+++ b/.github/workflows/rubyzen-analysis.yml
@@ -1,8 +1,8 @@
-name: RubyZen Analysis
+name: Rubyzen Analysis
 
 on:
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 jobs:

--- a/lib/rubyzen/collections/blocks_collection.rb
+++ b/lib/rubyzen/collections/blocks_collection.rb
@@ -1,0 +1,16 @@
+module Rubyzen
+  module Collections
+    class BlocksCollection < BaseCollection
+      include Rubyzen::Providers::CollectionFilterProvider
+
+      def with_method_name(method_name)
+        filter { |block| block.method_name == method_name }
+      end
+
+      def call_sites
+        all_call_sites = flat_map(&:call_sites)
+        CallSiteCollection.new(all_call_sites)
+      end
+    end
+  end
+end

--- a/lib/rubyzen/collections/call_site_collection.rb
+++ b/lib/rubyzen/collections/call_site_collection.rb
@@ -8,8 +8,20 @@ module Rubyzen
         filter { |call_site| call_site.receiver == receiver }
       end
 
+      def with_name(name)
+        filter { |call_site| call_site.name == name }
+      end
+
       def with_method_name(method_name)
-        filter { |call_site| call_site.method_name == method_name }
+        with_name(method_name)
+      end
+
+      def with_symbol(symbol)
+        filter { |call_site| call_site.symbols.include?(symbol) }
+      end
+
+      def with_keyword_arg(keyword_arg)
+        filter { |call_site| call_site.keyword_args.include?(keyword_arg) }
       end
     end
   end

--- a/lib/rubyzen/collections/file_collection.rb
+++ b/lib/rubyzen/collections/file_collection.rb
@@ -35,6 +35,16 @@ module Rubyzen
         all_requires = flat_map(&:requires)
         RequiresCollection.new(all_requires)
       end
+
+      def call_sites
+        all_call_sites = flat_map(&:call_sites)
+        CallSiteCollection.new(all_call_sites)
+      end
+
+      def blocks
+        all_blocks = flat_map(&:blocks)
+        BlocksCollection.new(all_blocks)
+      end
     end
   end
 end

--- a/lib/rubyzen/declarations/block_declaration.rb
+++ b/lib/rubyzen/declarations/block_declaration.rb
@@ -7,6 +7,8 @@ module Rubyzen
       include Rubyzen::Providers::LinesOfCodeProvider
       include Rubyzen::Providers::RescuesProvider
       include Rubyzen::Providers::RaisesProvider
+      include Rubyzen::Providers::SourceCodeProvider
+      include Rubyzen::Providers::CallSiteProvider
 
       attr_reader :node, :parent
 
@@ -16,7 +18,11 @@ module Rubyzen
       end
 
       def name
-        parent.name
+        method_name
+      end
+
+      def method_name
+        node.method_name.to_s
       end
     end
   end

--- a/lib/rubyzen/declarations/call_site_declaration.rb
+++ b/lib/rubyzen/declarations/call_site_declaration.rb
@@ -27,22 +27,36 @@ module Rubyzen
       end
 
       def keyword_args
-         extract_keyword_args(node)
-      end
+        node.arguments.flat_map do |arg|
+          next [] unless arg.hash_type?
 
-      private
-
-      def extract_keyword_args(send_node)
-        send_node.arguments.flat_map do |arg|
-          if arg.hash_type?
-            arg.each_pair.map do |pair|
-              key_node = pair.key
-              key_node.type == :sym ? key_node.value : nil
-            end.compact
-          else
-            []
+          arg.pairs.filter_map do |pair|
+            pair.key.value if pair.key.type == :sym
           end
         end.uniq
+      end
+
+      def keyword_arg_value_pairs
+        result = {}
+        node.arguments.each do |arg|
+          next unless arg.hash_type?
+
+          arg.pairs.each do |pair|
+            next unless pair.key.type == :sym
+
+            value_node = pair.value
+            result[pair.key.value] = value_node.respond_to?(:value) ? value_node.value : nil
+          end
+        end
+        result
+      end
+
+      def symbols
+        node.arguments.select { |arg| arg.type == :sym }.map(&:value)
+      end
+
+      def strings
+        node.arguments.select { |arg| arg.type == :str }.map(&:value)
       end
 
     end

--- a/lib/rubyzen/declarations/file_declaration.rb
+++ b/lib/rubyzen/declarations/file_declaration.rb
@@ -6,6 +6,8 @@ module Rubyzen
       include Rubyzen::Providers::LinesOfCodeProvider
       include Rubyzen::Providers::ConstantsProvider
       include Rubyzen::Providers::RequiresProvider
+      include Rubyzen::Providers::CallSiteProvider
+      include Rubyzen::Providers::BlocksProvider
 
       attr_reader :path, :node
       alias :ast :node

--- a/lib/rubyzen/matchers/be_false_matcher.rb
+++ b/lib/rubyzen/matchers/be_false_matcher.rb
@@ -21,10 +21,10 @@ RSpec::Matchers.define :be_false do |custom_message=nil|
   end
 
   failure_message do |_|
-    message_for_failure("Expected to be empty, but had elements.\n#{@offenders.join("\n")}")
+    message_for_failure("Expected to return false for all elements, but returned true for:\n#{@offenders.join("\n")}")
   end
 
   failure_message_when_negated do |_|
-    message_for_failure("Expected not to be empty, but had no elements:\n#{@offenders.join("\n")}")
+    message_for_failure("Expected to return true for at least one element, but returned false for:\n#{@offenders.join("\n")}")
   end
 end

--- a/lib/rubyzen/matchers/be_true_matcher.rb
+++ b/lib/rubyzen/matchers/be_true_matcher.rb
@@ -22,10 +22,10 @@ RSpec::Matchers.define :be_true do |custom_message=nil|
   end
 
   failure_message do |_|
-    message_for_failure("Expected to be empty, but had elements.\n#{@offenders.join("\n")}")
+    message_for_failure("Expected to return true for all elements, but returned false for:\n#{@offenders.join("\n")}")
   end
 
   failure_message_when_negated do |_|
-    message_for_failure("Expected not to be empty, but had no elements:\n#{@offenders.join("\n")}")
+    message_for_failure("Expected to return false for at least one element, but returned true for:\n#{@offenders.join("\n")}")
   end
 end

--- a/lib/rubyzen/providers/blocks_provider.rb
+++ b/lib/rubyzen/providers/blocks_provider.rb
@@ -2,9 +2,11 @@ module Rubyzen
   module Providers
     module BlocksProvider
       def blocks
-        node.each_node(:block).map do |block_node|
-          Rubyzen::Declarations::BlockDeclaration.new(block_node, self)
-        end
+        Collections::BlocksCollection.new(
+          node.each_descendant(:block).map do |block_node|
+            Declarations::BlockDeclaration.new(block_node, self)
+          end
+        )
       end
     end
   end

--- a/sample_project/spec/tests/limit_let_block_size_lint_spec.rb
+++ b/sample_project/spec/tests/limit_let_block_size_lint_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+RSpec.describe 'Limit let block size in test files' do
+  let(:max_let_lines) { 5 }
+
+  context 'given test files with let blocks' do
+    let(:test_source_files) { project.files.with_paths('src/tests/') }
+
+    let(:let_blocks) do
+      test_source_files.blocks.with_method_name('let')
+    end
+
+    it 'does not have let blocks exceeding the max line limit' do
+      expect(let_blocks).to be_false { |block| block.lines_of_code > max_let_lines }
+    end
+  end
+end

--- a/sample_project/spec/tests/no_hardcoded_coordinates_in_factories_lint_spec.rb
+++ b/sample_project/spec/tests/no_hardcoded_coordinates_in_factories_lint_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Use location traits instead of hardcoded coordinates in profile 
 
     it 'does not hardcode latitude and longitude in profile factory calls' do
       expect(profile_factory_calls).to be_false { |cs|
-        cs.keyword_arg_value_pairs[:latitude].is_a?(Numeric) &&
+        cs.keyword_arg_value_pairs[:latitude].is_a?(Numeric) ||
           cs.keyword_arg_value_pairs[:longitude].is_a?(Numeric)
       }
     end

--- a/sample_project/spec/tests/no_hardcoded_coordinates_in_factories_lint_spec.rb
+++ b/sample_project/spec/tests/no_hardcoded_coordinates_in_factories_lint_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+RSpec.describe 'Use location traits instead of hardcoded coordinates in profile factories' do
+  context 'given test files' do
+    let(:test_source_files) { project.files.with_paths('src/tests/') }
+
+    let(:profile_factory_calls) do
+      test_source_files.call_sites
+        .with_name('create')
+        .with_symbol(:profile)
+    end
+
+    it 'does not hardcode latitude and longitude in profile factory calls' do
+      expect(profile_factory_calls).to be_false { |cs|
+        cs.keyword_arg_value_pairs[:latitude].is_a?(Numeric) &&
+          cs.keyword_arg_value_pairs[:longitude].is_a?(Numeric)
+      }
+    end
+  end
+end

--- a/sample_project/src/tests/profile_factory_test.rb
+++ b/sample_project/src/tests/profile_factory_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Profile factory tests' do
+  context 'with lat long' do
+    let(:some_profile) { create(:profile, latitude: 40.753297, longitude: -73.980845) }
+
+    it 'creates a valid profile' do
+      expect(some_profile.latitude).to eq(40.753297)
+      expect(some_profile.longitude).to eq(-73.980845)
+    end
+  end
+
+  context 'with a location trait' do
+    let(:some_profile) { create(:profile, :brooklyn) }
+
+    it 'creates a valid profile' do
+      expect(some_profile.latitude).to eq(40.6782)
+      expect(some_profile.longitude).to eq(-73.9442)
+    end
+  end
+end

--- a/sample_project/src/tests/user_search_test.rb
+++ b/sample_project/src/tests/user_search_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe 'User search' do
+  let(:complex_query) do
+    User
+      .where(active: true)
+      .where(verified: true)
+      .where('created_at > ?', 30.days.ago)
+      .order(:name)
+      .limit(10)
+      .includes(:profile)
+      .references(:profile)
+  end
+
+  let(:simple_user) { create(:user) }
+
+  it 'should include the simple user in the complex query results' do
+    expect(complex_query).to include(simple_user)
+  end
+end


### PR DESCRIPTION
New Rubyzen APIs to improve writing lint rules for our tests:
- Added missing `call_sites` in `FileDeclaration`
- Added `blocks` in `FileDeclaration`
- Added `CallSiteProvider` in `BlockDeclaration`
- Added `BlocksCollection`
- Added `keyword_arg_value_pairs` in `CallSiteDeclaration`

Example lint rule we had before, parsing nodes manually:
```Ruby
let(:all_call_sites) do
  test_files.without_paths(*baseline).flat_map do |file|
    file.ast.each_node(:send).map do |node|
      Rubyzen::Declarations::CallSiteDeclaration.new(node, file)
    end
  end
end

let(:profile_factory_call_sites) do
  all_call_sites.filter do |cs|
    cs.method_name.to_s == "create" &&
      cs.source_code.include?(':profile')
  end
end

let(:violations) do
  profile_factory_call_sites.filter do |cs|
    (cs.source_code.match?(/\blatitude:\s*['"]?[-+]?\d+(\.\d+)?['"]?/) ||
     cs.source_code.match?(/\blatitude:\s*-\d+(\.\d+)?/)) &&
      (cs.source_code.match?(/\blongitude:\s*['"]?[-+]?\d+(\.\d+)?['"]?/) ||
       cs.source_code.match?(/\blongitude:\s*-\d+(\.\d+)?/))
  end
end

it 'uses location traits instead of hardcoded coordinates' do
  expect(violations).to be_empty
end
```

This can be now written as:
```Ruby
let(:profile_factory_calls) do
  test_files.without_paths(*baseline)
    .call_sites
    .with_name('create')
    .with_symbol(:profile)
end

it 'uses location traits instead of hardcoded coordinates' do
  expect(profile_factory_calls).to be_false { |cs|
    cs.keyword_arg_value_pairs[:latitude].is_a?(Numeric) &&
      cs.keyword_arg_value_pairs[:longitude].is_a?(Numeric)
  }
end
```

In addition, we can now parse directly any block of code in our tests:
```Ruby
test_files.blocks.with_method_name('describe') # All describe blocks
test_files.blocks.with_method_name('context') # All context blocks
test_files.blocks.with_method_name('let') # All let blocks
```